### PR TITLE
feat(app): adding missing reconcile start opt

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	appName = "controller"
+	appName = "vector-config-controller"
 )
 
 type (
@@ -50,7 +50,11 @@ func NewApp(l *slog.Logger) (*App, error) {
 }
 
 func (a *App) Start() error {
-	if err := a.base.Start(); err != nil {
+	if err := a.base.Start(
+		web.WithInClusterKubeClient(),
+		web.WithLeaderElection(appName),
+		web.WithIndefiniteAsyncTask("reconcile", a.Reconcile),
+	); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/controller/reconcile.go
+++ b/cmd/controller/reconcile.go
@@ -68,7 +68,7 @@ func reconcile(
 		kubeClient,
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "vector-logs-config",
+				Name:      "vector-agent-config",
 				Namespace: "vector",
 				Labels: map[string]string{
 					"owner": appName,


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request introduces updates to the `controller` application to improve its functionality and maintainability. Key changes include renaming the application, enhancing the reconciliation logic, and improving logging granularity.

### Application updates:

* Renamed the application from `"controller"` to `"vector-config-controller"` by updating the `appName` constant in `cmd/controller/main.go`.

### Reconciliation logic improvements:

* Updated the `Start` method in `cmd/controller/main.go` to include additional configurations: in-cluster Kubernetes client, leader election, and an indefinite asynchronous reconciliation task.
* Modified the `Reconcile` method in `cmd/controller/reconcile.go` to remove the error return type, ensuring the reconciliation loop continues even after encountering errors.
* Enhanced the `Reconcile` method to use `Debug` logs instead of `Info` logs for non-critical messages, improving log verbosity control.
* Updated the `reconcile` function to dynamically use the `appName` constant for labeling Kubernetes resources, ensuring consistency with the application's name.