### PR TITLE
feat(cicd): adding cache save always

### DIFF
--- a/.github/workflows/ci-code-approval.yml
+++ b/.github/workflows/ci-code-approval.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           path: "~/.cache/bazel"
           key: bazel-code-approval
+          save-always: true
 
       - name: Build and Test
         uses: magefile/mage-action@v3
@@ -87,6 +88,7 @@ jobs:
         with:
           path: "~/.cache/bazel"
           key: bazel-code-approval-diff
+          save-always: true
 
       - name: Run Mage
         uses: magefile/mage-action@v3

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           path: "~/.cache/bazel"
           key: bazel-docker-build
+          save-always: true
 
       - name: Build Mage command
         run: |


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request updates several GitHub Actions workflow files to ensure that Bazel cache artifacts are always saved, regardless of the workflow's outcome. This change aims to improve caching reliability and reduce redundant builds.

### Workflow updates for caching:

* [`.github/workflows/ci-code-approval.yml`](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50R65): Added the `save-always: true` option to the cache steps for both `bazel-code-approval` and `bazel-code-approval-diff` to ensure the Bazel cache is saved even if the workflow fails. [[1]](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50R65) [[2]](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50R91)
* [`.github/workflows/ci-docker.yml`](diffhunk://#diff-9332b316f4d0b2466d2975fc710b57c5186d41091efc51181c0ad82a039b885fR58): Added the `save-always: true` option to the cache step for `bazel-docker-build` to ensure the Bazel cache is saved even if the workflow fails.