### PR TITLE
feat(cicd): manual save and load of cache for bazel

### DIFF
--- a/.github/workflows/ci-code-approval.yml
+++ b/.github/workflows/ci-code-approval.yml
@@ -57,17 +57,26 @@ jobs:
           go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
 
-      - name: Mount bazel cache
-        uses: actions/cache@v4
+      - name: Restore bazel cache
+        uses: actions/cache/restore@v4
         with:
-          path: "~/.cache/bazel"
           key: bazel-code-approval
+          path: |
+            ~/.cache/bazel
 
       - name: Build and Test
         uses: magefile/mage-action@v3
         with:
           version: latest
           args: -v build test
+
+      - name: Save bazel cache
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          key: bazel-code-approval
+          path: |
+            ~/.cache/bazel
 
   diff:
     name: "Diff"
@@ -82,11 +91,12 @@ jobs:
           go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
 
-      - name: Mount bazel cache
-        uses: actions/cache@v4
+      - name: Restore bazel cache
+        uses: actions/cache/restore@v4
         with:
-          path: "~/.cache/bazel"
           key: bazel-code-approval-diff
+          path: |
+            ~/.cache/bazel
 
       - name: Run Mage
         uses: magefile/mage-action@v3
@@ -103,3 +113,11 @@ jobs:
             echo "Make sure to run 'mage fixit' before committing."
             exit 1
           fi
+
+      - name: Save bazel cache
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          key: bazel-code-approval-diff
+          path: |
+            ~/.cache/bazel

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -50,11 +50,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Mount bazel cache
-        uses: actions/cache@v4
+      - name: Restore bazel cache
+        uses: actions/cache/restore@v4
         with:
-          path: "~/.cache/bazel"
           key: bazel-docker-build
+          path: |
+            ~/.cache/bazel
 
       - name: Build Mage command
         run: |
@@ -79,6 +80,10 @@ jobs:
         env:
           PUSH_IMAGES: ${{ github.event_name != 'pull_request' }}
 
-      - name: Clean Docker
-        if: ${{ always() }}
-        run: docker system prune -af
+      - name: Save bazel cache
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          key: bazel-docker-build
+          path: |
+            ~/.cache/bazel


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request updates the caching strategy for Bazel in the CI workflows by replacing the `actions/cache` v4 usage with separate `actions/cache/restore` and `actions/cache/save` steps. The changes ensure that the Bazel cache is restored at the start and saved at the end of relevant jobs, improving cache handling consistency.

### Changes to `.github/workflows/ci-code-approval.yml`:

* Replaced the `actions/cache` step for Bazel with `actions/cache/restore` to restore the cache at the beginning of the `build` and `diff` jobs. [[1]](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50L60-R80) [[2]](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50L85-R99)
* Added `actions/cache/save` steps to save the Bazel cache at the end of the `build` and `diff` jobs, ensuring the cache is updated after the job execution. [[1]](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50L60-R80) [[2]](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50R116-R123)

### Changes to `.github/workflows/ci-docker.yml`:

* Replaced the `actions/cache` step for Bazel with `actions/cache/restore` to restore the cache at the beginning of the Docker build job.
* Added an `actions/cache/save` step to save the Bazel cache at the end of the Docker build job, replacing the previous Docker cleanup step.