### PR TITLE
fix(app): correcting tag for the env default

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -19,7 +19,7 @@ type (
 	// AppConfig is the configuration for the app.
 	AppConfig struct {
 		// TickerInterval is the interval for the ticker.
-		TickerInterval time.Duration `env:"TICKER_INTERVAL" default:"10s"`
+		TickerInterval time.Duration `env:"TICKER_INTERVAL" envDefault:"10s"`
 	}
 
 	// App is the main application struct.


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes a minor update to the `AppConfig` struct in `cmd/controller/main.go` to align with a standardized configuration library.

* [`cmd/controller/main.go`](diffhunk://#diff-369ede0a9a64763f9a3f47aa07fa8a9d1062b3df2783458f02e49cf7f1f3554dL22-R22): Replaced the `default` tag with `envDefault` in the `TickerInterval` field to ensure compatibility with the environment variable parsing library.