### PR TITLE
chore(cicd): using a single bazel cache

### DIFF
--- a/.github/workflows/ci-code-approval.yml
+++ b/.github/workflows/ci-code-approval.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Restore bazel cache
         uses: actions/cache/restore@v4
         with:
-          key: bazel-code-approval
+          key: bazel
           path: |
             ~/.cache/bazel
 
@@ -74,7 +74,7 @@ jobs:
         uses: actions/cache/save@v4
         if: always()
         with:
-          key: bazel-code-approval
+          key: bazel
           path: |
             ~/.cache/bazel
 
@@ -94,7 +94,7 @@ jobs:
       - name: Restore bazel cache
         uses: actions/cache/restore@v4
         with:
-          key: bazel-code-approval-diff
+          key: bazel
           path: |
             ~/.cache/bazel
 
@@ -113,11 +113,3 @@ jobs:
             echo "Make sure to run 'mage fixit' before committing."
             exit 1
           fi
-
-      - name: Save bazel cache
-        uses: actions/cache/save@v4
-        if: always()
-        with:
-          key: bazel-code-approval-diff
-          path: |
-            ~/.cache/bazel

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Restore bazel cache
         uses: actions/cache/restore@v4
         with:
-          key: bazel-docker-build
+          key: bazel
           path: |
             ~/.cache/bazel
 
@@ -84,6 +84,6 @@ jobs:
         uses: actions/cache/save@v4
         if: always()
         with:
-          key: bazel-docker-build
+          key: bazel
           path: |
             ~/.cache/bazel


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request simplifies the Bazel cache configuration in GitHub Actions workflows by standardizing the cache key across multiple workflows and removing redundant cache-saving steps.

### Standardization of Bazel cache keys:
* [`.github/workflows/ci-code-approval.yml`](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50L63-R63): Updated the cache key from `bazel-code-approval` and `bazel-code-approval-diff` to a standardized `bazel` key for both restore and save steps. [[1]](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50L63-R63) [[2]](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50L77-R77) [[3]](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50L97-R97)
* [`.github/workflows/ci-docker.yml`](diffhunk://#diff-9332b316f4d0b2466d2975fc710b57c5186d41091efc51181c0ad82a039b885fL56-R56): Updated the cache key from `bazel-docker-build` to the standardized `bazel` key for both restore and save steps. [[1]](diffhunk://#diff-9332b316f4d0b2466d2975fc710b57c5186d41091efc51181c0ad82a039b885fL56-R56) [[2]](diffhunk://#diff-9332b316f4d0b2466d2975fc710b57c5186d41091efc51181c0ad82a039b885fL87-R87)

### Removal of redundant cache-saving steps:
* [`.github/workflows/ci-code-approval.yml`](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50L116-L123): Removed an unnecessary step for saving the `bazel-code-approval-diff` cache, as it is no longer needed.