### PR TITLE
feat(cicd): upgrading the mage builds

### DIFF
--- a/magefiles/bazel.go
+++ b/magefiles/bazel.go
@@ -27,3 +27,9 @@ var outputDirectory = sync.OnceValue(func() string {
 
 	return dir
 })
+
+// appendBazelBuildArgs appends additional Bazel build arguments to the provided slice of arguments.
+func appendBazelBuildArgs(args []string) []string {
+	args = append(args, "--@io_bazel_rules_go//go/config:race")
+	return args
+}

--- a/magefiles/bazel.go
+++ b/magefiles/bazel.go
@@ -28,8 +28,8 @@ var outputDirectory = sync.OnceValue(func() string {
 	return dir
 })
 
-// appendBazelBuildArgs appends additional Bazel build arguments to the provided slice of arguments.
-func appendBazelBuildArgs(args []string) []string {
+// appendBazelArgs appends additional Bazel arguments to the provided slice of arguments.
+func appendBazelArgs(args []string) []string {
 	args = append(args, "--@io_bazel_rules_go//go/config:race")
 	return args
 }

--- a/magefiles/build.go
+++ b/magefiles/build.go
@@ -25,7 +25,7 @@ func (b Build) All() error {
 	}
 
 	if isCIRunner() {
-		args = appendBazelBuildArgs(args)
+		args = appendBazelArgs(args)
 	}
 	args = append(args, "//...")
 
@@ -49,7 +49,7 @@ func (b Build) One(service string) error {
 	}
 
 	if isCIRunner() {
-		args = appendBazelBuildArgs(args)
+		args = appendBazelArgs(args)
 	}
 	args = append(args, "//cmd/"+service)
 

--- a/magefiles/build.go
+++ b/magefiles/build.go
@@ -27,7 +27,6 @@ func (b Build) All() error {
 	if isCIRunner() {
 		args = appendBazelBuildArgs(args)
 	}
-
 	args = append(args, "//...")
 
 	if err := sh.Run("bazel", args...); err != nil {
@@ -52,7 +51,6 @@ func (b Build) One(service string) error {
 	if isCIRunner() {
 		args = appendBazelBuildArgs(args)
 	}
-
 	args = append(args, "//cmd/"+service)
 
 	if err := sh.Run("bazel", args...); err != nil {

--- a/magefiles/build.go
+++ b/magefiles/build.go
@@ -22,8 +22,13 @@ func (b Build) All() error {
 
 	args := []string{
 		"build",
-		"//...",
 	}
+
+	if isCIRunner() {
+		args = appendBazelBuildArgs(args)
+	}
+
+	args = append(args, "//...")
 
 	if err := sh.Run("bazel", args...); err != nil {
 		return fmt.Errorf("error building all code: %w", err)
@@ -42,8 +47,13 @@ func (b Build) One(service string) error {
 
 	args := []string{
 		"build",
-		"//cmd/" + service,
 	}
+
+	if isCIRunner() {
+		args = appendBazelBuildArgs(args)
+	}
+
+	args = append(args, "//cmd/"+service)
 
 	if err := sh.Run("bazel", args...); err != nil {
 		return fmt.Errorf("error building %s: %w", service, err)

--- a/magefiles/test.go
+++ b/magefiles/test.go
@@ -20,9 +20,12 @@ func (Test) Unit() error {
 
 	args := []string{
 		"test",
-		"--@io_bazel_rules_go//go/config:race",
-		"--test_arg=--test.shuffle=on",
 	}
+
+	if isCIRunner() {
+		args = appendBazelBuildArgs(args)
+	}
+	args = append(args, "--test_arg=--test.shuffle=on")
 
 	args = append(args, "//...")
 

--- a/magefiles/test.go
+++ b/magefiles/test.go
@@ -23,7 +23,7 @@ func (Test) Unit() error {
 	}
 
 	if isCIRunner() {
-		args = appendBazelBuildArgs(args)
+		args = appendBazelArgs(args)
 	}
 	args = append(args, "--test_arg=--test.shuffle=on")
 


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request introduces a utility function to append Bazel arguments conditionally and updates build and test workflows to incorporate this function. The changes aim to streamline argument handling and ensure consistent behavior in CI environments.

### Utility Function Addition:
* Added a new function, `appendBazelArgs`, in `magefiles/bazel.go` to append Bazel arguments, specifically the `--@io_bazel_rules_go//go/config:race` flag.

### Build Workflow Updates:
* In `magefiles/build.go`, updated the `Build.All` and `Build.One` methods to use the new `appendBazelArgs` function when running in a CI environment. This ensures that the race detection flag is included conditionally. [[1]](diffhunk://#diff-01ca54a2efd573bb1426a7e2038929257a79b0914edfdb976ef090ef4322f5fcL25-R31) [[2]](diffhunk://#diff-01ca54a2efd573bb1426a7e2038929257a79b0914edfdb976ef090ef4322f5fcL45-R55)

### Test Workflow Updates:
* In `magefiles/test.go`, updated the `Test.Unit` method to use `appendBazelArgs` for appending the race detection flag in CI environments, while also appending the test shuffle argument separately.