### PR TITLE
chore(cicd): no save cache on docker cicd

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -79,11 +79,3 @@ jobs:
           args: -v ${{ env.MAGE_COMMAND }}
         env:
           PUSH_IMAGES: ${{ github.event_name != 'pull_request' }}
-
-      - name: Save bazel cache
-        uses: actions/cache/save@v4
-        if: always()
-        with:
-          key: bazel
-          path: |
-            ~/.cache/bazel


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes a change to the `.github/workflows/ci-docker.yml` file, specifically removing an unnecessary step related to saving the Bazel cache. 

Workflow simplification:

* [`.github/workflows/ci-docker.yml`](diffhunk://#diff-9332b316f4d0b2466d2975fc710b57c5186d41091efc51181c0ad82a039b885fL82-L89): Removed the "Save bazel cache" step, which included the `actions/cache/save@v4` action, as it is no longer required.